### PR TITLE
Minor fixes: do not leave temporary files behind

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -304,7 +304,7 @@ garbage() {
 	fi
 }
 
-trap garbage INT
+trap "garbage ; exit 2" INT
 
 BEGIN=`date +%s`
 

--- a/rad_eap_test
+++ b/rad_eap_test
@@ -218,6 +218,22 @@ if [ -n "$REQUEST_CUI" ] ; then
 	EXTRA_EAPOL_ARGS="$EXTRA_EAPOL_ARGS -N89:x:00"
 fi
 
+# address may be address or ip address
+IP=`echo $ADRESS | grep --regexp="^[[:digit:]+\.[:digit:]+\.[:digit:]+\.[:digit:]]"`
+if [ -z "$IP" ]; then
+  #IP=`host $ADRESS | tail -n 1 | awk '{print $3}'`
+  IP=`dig +noall +answer +search $ADRESS | tr \\\t ' ' | grep ' IN A ' | sed "s/.* IN A //"`
+fi
+
+# Sanity check: did we get an IP address?
+if [ -z "$IP" ] ; then
+  echo "Hostname $ADRESS could not be resolved to an IP address."
+  exit 2;
+fi
+
+#echo $IP
+
+
 # temporary file of eapol_test configuration
 if [ -z $TMPDIR ]; then
   MYTMPDIR=`mktemp -d /tmp/rad_eap_test.XXXXXX`
@@ -272,16 +288,6 @@ echo "}" >> $CONF
 
 #echo $EAP
 #cat $CONF
-
-# address may be address or ip address
-IP=`echo $ADRESS | grep --regexp="^[[:digit:]+\.[:digit:]+\.[:digit:]+\.[:digit:]]"`
-if [ -z "$IP" ]; then 
-  #IP=`host $ADRESS | tail -n 1 | awk '{print $3}'`
-  IP=`dig +noall +answer +search $ADRESS | tr \\\t ' ' | grep ' IN A ' | sed "s/.* IN A //"`
-fi
-
-
-#echo $IP
 
 # garbage
 garbage() {

--- a/rad_eap_test
+++ b/rad_eap_test
@@ -13,19 +13,6 @@
 # umask
 umask 0077
 
-# temporary file of eapol_test configuration 
-if [ -z $TMPDIR ]; then
-  MYTMPDIR=`mktemp -d /tmp/rad_eap_test.XXXXXX`
-else
-  MYTMPDIR=`mktemp -d $TMPDIR/rad_eap_test.XXXXXX`
-fi
-
-CONF=$MYTMPDIR/tmp-$$
-OUT=$CONF.out
-OUT2=$CONF.out2
-
-#echo $CONF $OUT
-
 # path to eapol test
 EAPOL_PROG=bin/eapol_test
 
@@ -230,6 +217,19 @@ fi
 if [ -n "$REQUEST_CUI" ] ; then
 	EXTRA_EAPOL_ARGS="$EXTRA_EAPOL_ARGS -N89:x:00"
 fi
+
+# temporary file of eapol_test configuration
+if [ -z $TMPDIR ]; then
+  MYTMPDIR=`mktemp -d /tmp/rad_eap_test.XXXXXX`
+else
+  MYTMPDIR=`mktemp -d $TMPDIR/rad_eap_test.XXXXXX`
+fi
+
+CONF=$MYTMPDIR/tmp-$$
+OUT=$CONF.out
+OUT2=$CONF.out2
+
+#echo $CONF $OUT
 
 # generation of configuration
 echo "network={" > $CONF


### PR DESCRIPTION
Zdravim,

I've noticed rad_eap_test was leaving the temporary files behind when the DNS was unreachable.

After detailed checking, I found it was because the `dig` command was returning empty output - and this wasn't checked anywhere.

I have:
- added a sanity check on the dig output (one more check for `IP` being non-empty)
  - Here, I was deciding between exiting with exit code 3 (invalid configuration) or 2 (critical).  Invalid hostname would be better matched with a `3`, unreachable DNS with a `2` - decided for a `2`, also following guidelines at https://nagios-plugins.org/doc/guidelines.html#AEN78
- slightly re-arranged when the temporary directory is created so that it is not left behind when rad_eap_test exits when doing sanity checks on command-line arguments.
- added an "exit 2" command to the INT signal handler (so far just calling the garbage() cleanup function).  I assume the intention was to exit when receiving SIGINT - but that has to be done explicitly in the signal handler - otherwise the shell script tries to continue (and gets very confused as the temporary directory has already been deleted).

Please let me know whether you are happy to merge these in.

Cheers,
Vlada Mencl
