### PR TITLE
Provide performance data

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -306,7 +306,7 @@ garbage() {
 
 trap "garbage ; exit 2" INT
 
-BEGIN=`date +%s`
+BEGIN=`date +%s.%N`
 
 #echo "$EAPOL_PROG -c$CONF -a$IP -p$PORT -s$SECRET -t$TIMEOUT -M$MAC -C"$CONN_INFO" $EXTRA_EAPOL_ARGS $STATUS_DIR"
 
@@ -325,8 +325,10 @@ fi
 
 RETURN_CODE=$?
 
-END=`date +%s`
-T=$((END-BEGIN))
+END=`date +%s.%N`
+#T=$((END-BEGIN))
+T=$(echo "$END-$BEGIN" | bc)
+TU=$(echo "$T * 1000" | bc)
 
 #echo $RETURN_CODE
 
@@ -342,7 +344,8 @@ fi
 # processing of return code
 # Successfull authentication
 if [ $RETURN_CODE -eq $RET_SUCC ]; then
-  echo "access-accept; $T"
+  printf "access-accept; %0.2f sec " $T
+  printf "|rtt=%0.0fus;;;0;%d accept=1;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi
@@ -354,7 +357,8 @@ fi
 # Bad name or password
 # string "CTRL-EVENT-EAP-FAILURE EAP authentication failed"
 if [ $RETURN_CODE -eq $RET_EAP_FAILED ]; then
-  echo "access-reject; $T"
+  printf "access-reject; %0.2f sec " $T
+  printf "|rtt=%0.0fus;;;0;%d accept=0.5;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi
@@ -366,8 +370,8 @@ fi
 # timeout return same error as above
 # timeout string "EAPOL test timed out"
 if [ $RETURN_CODE -eq $RET_RADIUS_NOT_AVAIL ]; then
-  #echo "Timeout : Radius server is not available"
-  echo "timeout; $T"
+  printf "timeout; %0.0f sec " $T
+  printf "|rtt=%0.0fus;;;0;%d accept=0;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi

--- a/rad_eap_test
+++ b/rad_eap_test
@@ -345,7 +345,7 @@ fi
 # Successfull authentication
 if [ $RETURN_CODE -eq $RET_SUCC ]; then
   printf "access-accept; %0.2f sec " $T
-  printf "|rtt=%0.0fus;;;0;%d accept=1;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
+  printf "|rtt=%0.0fms;;;0;%d accept=1;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi
@@ -358,7 +358,7 @@ fi
 # string "CTRL-EVENT-EAP-FAILURE EAP authentication failed"
 if [ $RETURN_CODE -eq $RET_EAP_FAILED ]; then
   printf "access-reject; %0.2f sec " $T
-  printf "|rtt=%0.0fus;;;0;%d accept=0.5;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
+  printf "|rtt=%0.0fms;;;0;%d accept=0.5;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi
@@ -371,7 +371,7 @@ fi
 # timeout string "EAPOL test timed out"
 if [ $RETURN_CODE -eq $RET_RADIUS_NOT_AVAIL ]; then
   printf "timeout; %0.0f sec " $T
-  printf "|rtt=%0.0fus;;;0;%d accept=0;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
+  printf "|rtt=%0.0fms;;;0;%d accept=0;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi


### PR DESCRIPTION
This change adds nagios-style performance data, at the expense of adding a dependency on bc (for floating point support). This further allows us to integrate with things like pnp4nagios to draw graphs of round-trip time and accept/reject.

See https://monitor.eduroam.ac.za/eduroam/thruk/cgi-bin/extinfo.cgi?type=2&host=flr-cpt.eduroam.ac.za&service=realm-tenet_ac_za&nav=0&minimal=1 for an example of the perfdata output.