### PR TITLE
cleanup also on SIGTERM

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -304,7 +304,7 @@ garbage() {
 	fi
 }
 
-trap "garbage ; exit 2" INT
+trap "garbage ; exit 2" INT TERM
 
 BEGIN=`date +%s`
 


### PR DESCRIPTION
Pokud je monitoring restartovan prave kdyz probiha nejaky rad_eap_test, je skript nasilne ukoncen a zbydou po nem pracovni soubory. Tenhle patch by mel problem resit. 