### PR TITLE
Prefix the Operator_Name with NamespaceID value "1" (REALM) as per RFC5580

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -206,7 +206,8 @@ if [ -z $PHASE2 ]; then
 fi
 
 if [ -n "$OPERATOR_NAME" ] ; then
-	EXTRA_EAPOL_ARGS="$EXTRA_EAPOL_ARGS -N126:s:$OPERATOR_NAME"
+        # prefix the Operator_Name with NamespaceID value "1" (REALM) as per RFC5580
+	EXTRA_EAPOL_ARGS="$EXTRA_EAPOL_ARGS -N126:s:1$OPERATOR_NAME"
 fi
 
 if [ -n "$NAS_IP_ADDRESS" ] ; then


### PR DESCRIPTION
Hi @semik ,

When I added support for passing Operator_Name (-O), I completely missed that RFC5580 specifies that the value of Operator_Name (at Radius level) starts with a NamespaceID - which is "1" for REALM operator name values: https://tools.ietf.org/html/rfc5580#section-4.1

Sorry about that - fixing it now.

Please let me know if this is OK to merge.

Zdravim,
Vlada Mencl