### PR TITLE
Put perfdata after verbose output

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -437,7 +437,6 @@ fi
 # Successfull authentication
 if [ $RETURN_CODE -eq $RET_SUCC ]; then
   printf "access-accept; %0.2f sec " $T
-  printf "|rtt=%0.0fms;;;0;%d accept=1;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi
@@ -456,6 +455,7 @@ if [ $RETURN_CODE -eq $RET_SUCC ]; then
     printf "%s\n" "$(echo "$cert_info" | grep -A 2 'Validity' | sed 's/^[[:space:]]*//g')"
     printf "%s\n" "$(echo "$cert_info" | grep 'DNS:' | sed 's/^[[:space:]]*//g')"
   fi
+  printf "|rtt=%0.0fms;;;0;%d accept=1;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
 
   garbage
   exit 0;
@@ -465,10 +465,10 @@ fi
 # string "CTRL-EVENT-EAP-FAILURE EAP authentication failed"
 if [ $RETURN_CODE -eq $RET_EAP_FAILED ]; then
   printf "access-reject; %0.2f sec " $T
-  printf "|rtt=%0.0fms;;;0;%d accept=0.5;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi
+  printf "|rtt=%0.0fms;;;0;%d accept=0.5;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
 
   garbage
   exit 1;
@@ -478,10 +478,10 @@ fi
 # timeout string "EAPOL test timed out"
 if [ $RETURN_CODE -eq $RET_RADIUS_NOT_AVAIL ]; then
   printf "timeout; %0.0f sec " $T
-  printf "|rtt=%0.0fms;;;0;%d accept=0;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
   if [ $VERBOSE -gt 0 ]; then
 	  cat $OUT
   fi
+  printf "|rtt=%0.0fms;;;0;%d accept=0;0.5:;0:;0;1\n" $TU $((TIMEOUT * 1000))
 
   garbage
   exit 2;


### PR DESCRIPTION
If you happen to use verbose output and/or certificate information in a monitoring system, then either the performance data is discarded or the extended output is discarded. This is because most nagios clones expect everything after the pipe to be perfdata.

The patch moves perfdata output to after any verbose output.