### PR TITLE
Support -4 for compatibility with check_v46

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -648,6 +648,7 @@ Parameters :
 -V - Show received Chargeable-User-Identity and/or Operator-Name
 -X <warn_days> - check certificate expiry (whole certificate chain may be retrieved by eapol_test, there is a certain logic that tries to determine the end server cert which is checked for expiry)
 -6 force use of IPv6 when using DNS name as RADIUS server address
+-4 use IPv4 when using DNS name as RADIUS server address (this is the default, but the option exists for compatibility)
 -h - show this message
 " >&2
   exit 1
@@ -877,7 +878,7 @@ function check_settings()
 # ===========================================================================================
 function process_options()
 {
-  while getopts "H:P:S:u:p:t:m:s:e:t:M:i:d:j:k:a:A:l:2:x:vcNO:I:CTfhbB:n:gVX:6" opt
+  while getopts "H:P:S:u:p:t:m:s:e:t:M:i:d:j:k:a:A:l:2:x:vcNO:I:CTfhbB:n:gVX:64" opt
   do
     case "$opt" in
       H) ADDRESS=$OPTARG;;
@@ -914,6 +915,7 @@ function process_options()
       X) CERTIFICATE_EXPIRY=$OPTARG;;
       d) DOMAIN_MATCH="$OPTARG";;
       6) IPV6="YES";;
+      4) IPV6="NO";;
       h) usage;;
       \?) usage;;
     esac

--- a/rad_eap_test
+++ b/rad_eap_test
@@ -647,8 +647,8 @@ Parameters :
 -g - print the entire unmodified output of eapol_test
 -V - Show received Chargeable-User-Identity and/or Operator-Name
 -X <warn_days> - check certificate expiry (whole certificate chain may be retrieved by eapol_test, there is a certain logic that tries to determine the end server cert which is checked for expiry)
--6 force use of IPv6 when using DNS name as RADIUS server address
--4 use IPv4 when using DNS name as RADIUS server address (this is the default, but the option exists for compatibility)
+-6 - force use of IPv6 when using DNS name as RADIUS server address
+-4 - use IPv4 when using DNS name as RADIUS server address (this is the default, but the option exists for compatibility)
 -h - show this message
 " >&2
   exit 1


### PR DESCRIPTION
Debian systems include a [nagios-plugins-contrib](http://wiki.debian.org/PkgNagios) package that has a useful `check_v46` utility that allows Nagios plugins to run against both IPv4 and IPv6 systems (thus testing dual stacking is working properly). In order to support this, plugins must support both a -4 and a -6 options. This follows a convention supported by a wide range of plugins, including those from monitoring-plugins.org.

The change is effectively a no-op since `dig` defaults to looking up `A` records, but having support for the option means that we can drop rad_eap_test behind `check_v46` without any errors.