### PR TITLE
Allow setting autheap for phase2

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -578,7 +578,11 @@ function generate_config()
   then
     echo "  pairwise=CCMP TKIP" >> $CONF
     echo "  group=CCMP TKIP WEP104 WEP40" >> $CONF
-    echo "  phase2=\"auth=$PHASE2\"" >> $CONF
+    if [[ "$PHASE2" =~ ^EAP[_-] ]] ; then
+      echo "  phase2=\"autheap=${PHASE2#EAP[-_]}\"" >> $CONF
+    else
+      echo "  phase2=\"auth=$PHASE2\"" >> $CONF
+    fi
   fi
 
   if [[ ! -z "$CA_CRT" ]]
@@ -647,7 +651,7 @@ Parameters :
 -l <user_key_file_password> - password for user certificate key file
 -j <user_cert_file> - user certificate file
 -a <ca_cert_file> - certificate of CA
--2 <phase2 method> - Phase2 type (PAP,CHAP,MSCHAPV2)
+-2 <phase2 method> - Phase2 type (PAP,CHAP,MSCHAPV2,EAP-GTC)
 -x <subject_match> - Substring to be matched against the subject of the authentication server certificate.
 -N - Identify and do not delete temporary files
 -O <domain.edu.cctld> - Operator-Name value in domain name format


### PR DESCRIPTION
In order to test some phase2 types, we need to use `autheap=` rather than `auth=` in the eapol_test config. 

An example of where this is necessary is with EAP-TTLS/EAP-GTC or EAP-TTLS/EAP-MSCHAPv2 (as opposed to EAP-TTLS/MSCHAPv2). Our use case for it is testing GTC passwords.

This patch allows the phase2 type to explicitly specify that autheap= is required by prefixing the EAP type with `EAP-`. In other words, `-2 MSCHAPV2` will result in `auth=MSCHAPV2` but `-2 EAP-MSCHAPV2` will result in `autheap=MSCHAPV2`.