### PR TITLE
fix: correctly detect expired cert (vs CA)

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -388,7 +388,7 @@ function determine_return_code()
 
   local cert_expired="err='certificate has expired'"
   local cert_not_yet_valid="err='certificate is not yet valid'"
-  local root_cert="depth=0"                                # CA certs are validated at depth 0 (root). TODO: What about intermediate certs?
+  local leaf_cert="depth=0"                                # Leaf certs are validated at depth 0.  Intermediate certs (if any) and root are at numerically increasing depth.
   local domain_mismatch="err='Domain mismatch'"
 
   run_eapol_test
@@ -431,13 +431,13 @@ function determine_return_code()
     RETURN_CODE=$RET_CERT_CA_MISMATCH         # certificate not matching CA
     STATUS_CODE="access-reject (certificate not matching specified CA)"
 
-  elif [[ -n "$CA_CRT" && "$OUT" =~ $cert_expired && "(echo "$OUT" | grep "$cert_expired")" =~ $root_cert ]]        # root CA certificate expired
+  elif [[ -n "$CA_CRT" && "$OUT" =~ $cert_expired && ! "(echo "$OUT" | grep "$cert_expired")" =~ $leaf_cert ]]        # CA certificate expired (intermediate or root)
   then
     RETURN_CODE=$RET_CERT_EXPIRED             # certificate expired
     STATUS_CODE="access-reject (CA certificate expired [$(echo "$OUT" | grep "$cert_expired" | sed 's/^.*subject/subject/; s/ err=.*//')])"
 
   # certificate expired (a more complex logic would be probably needed to distinguish end server and intermediate certs)
-  elif [[ -n "$CA_CRT" && "$OUT" =~ $cert_expired && ! "(echo "$OUT" | grep "$cert_expired")" =~ $root_cert ]]
+  elif [[ -n "$CA_CRT" && "$OUT" =~ $cert_expired && "(echo "$OUT" | grep "$cert_expired")" =~ $leaf_cert ]]
   then
     RETURN_CODE=$RET_CERT_EXPIRED         # certificate expired
     STATUS_CODE="access-reject (certificate expired [$(echo "$OUT" | grep "$cert_expired" | sed 's/^.*subject/subject/; s/ err=.*//')])"


### PR DESCRIPTION
In OpenSSL certificate chain dump, depth=0 corresponds to the leaf (end-entity) certificate (not root CA).

rad_eap_test was incorrectly reporting `CA certificate expired` for an expired leaf certificate.

Fix the logic by:
* renaming the `depth=0` pattern from `root_certificate` to `leaf_certificate`
* swapping around whether the pattern should match (certificate) vs should not match (CA certificate)