### PR TITLE
new options for TLS protocol selection and generic phase1 options

### DIFF
--- a/rad_eap_test
+++ b/rad_eap_test
@@ -581,6 +581,11 @@ function generate_config()
     echo "  phase2=\"auth=$PHASE2\"" >> $CONF
   fi
 
+  if [[ -n "$PHASE1" ]]
+  then
+    echo "  phase1=\"$PHASE1\"" >> $CONF
+  fi
+
   if [[ ! -z "$CA_CRT" ]]
   then
     echo "  ca_cert=\"$CA_CRT\"" >> $CONF
@@ -647,6 +652,8 @@ Parameters :
 -l <user_key_file_password> - password for user certificate key file
 -j <user_cert_file> - user certificate file
 -a <ca_cert_file> - certificate of CA
+-L <TLS protocols> - comma-separated list of TLS protocols to enable - select from: TLSv1,TLSv1.1,TLSv1.2,TLSv1.3 (translates to phase1 options, -1).
+-1 <phase1_options> - set of options for phase1 (\"peapver=1 peaplabel=1\")
 -2 <phase2 method> - Phase2 type (PAP,CHAP,MSCHAPV2)
 -x <subject_match> - Substring to be matched against the subject of the authentication server certificate.
 -N - Identify and do not delete temporary files
@@ -672,6 +679,11 @@ Parameters :
 # ===========================================================================================
 function check_settings()
 {
+  local tls10_disabled
+  local tls11_disabled
+  local tls12_disabled
+  local tls13_disabled
+
   # check dependencies used in this script
   if [[ -z "$(which bc)" ]]
   then
@@ -793,6 +805,20 @@ function check_settings()
     SSID="eduroam";
   fi
 
+  if [[ -n "$TLS_PROTOCOLS" ]]
+  then
+    TLS_PROTOCOLS=",$TLS_PROTOCOLS," # for easier matching
+
+    # For each TLS protocol, if included in the list, exit value will be 0 and the protocol will be enabled.
+    [[ $TLS_PROTOCOLS =~ ,TLSv1, ]] ; tls10_disabled=$?
+    [[ $TLS_PROTOCOLS =~ ,TLSv1\.1, ]] ; tls11_disabled=$?
+    [[ $TLS_PROTOCOLS =~ ,TLSv1\.2, ]] ; tls12_disabled=$?
+    [[ $TLS_PROTOCOLS =~ ,TLSv1\.3, ]] ; tls13_disabled=$?
+
+    PHASE1="$PHASE1 tls_disable_tlsv1_0=$tls10_disabled tls_disable_tlsv1_1=$tls11_disabled tls_disable_tlsv1_2=$tls12_disabled tls_disable_tlsv1_3=$tls13_disabled"
+    PHASE1="${PHASE1# }" # trim leading whitespace - introduced above if PHASE1 was initially empty
+  fi
+
   if [[ -z "$PHASE2" ]]
   then
     PHASE2="MSCHAPV2"
@@ -892,7 +918,7 @@ function check_settings()
 # ===========================================================================================
 function process_options()
 {
-  while getopts "H:P:S:u:p:t:m:s:e:t:M:i:d:j:k:a:A:l:2:x:vcNO:I:CTfhbB:n:gVX:64" opt
+  while getopts "H:P:S:u:p:t:m:s:e:t:M:i:d:j:k:a:A:l:L:1:2:x:vcNO:I:CTfhbB:n:gVX:64" opt
   do
     case "$opt" in
       H) ADDRESS=$OPTARG;;
@@ -913,6 +939,8 @@ function process_options()
       a) CA_CRT=$OPTARG;;
       A) ANONYM_ID=$OPTARG;;
       l) KEY_PASS=$OPTARG;;
+      L) TLS_PROTOCOLS=$OPTARG;;
+      1) PHASE1="$OPTARG";;
       2) PHASE2=$OPTARG;;
       N) CLEANUP=0;;
       x) SUBJ_MATCH=$OPTARG;;


### PR DESCRIPTION
Add new option -L to allow selecting specific TLS protocols to enable.

Protocol names match existing use of OpenSSL config (so TLSv1.0 is "TLSv1").

The TLS protocol selection is translated into phase1 options included in the wpa_supplicant (eapol_test) configuration file (tls_disable_tlsv1_0, tls_disable_tlsv1_1, tls_disable_tlsv1_2, and tls_disable_tlsv1_3).

Example: enable only TLSv1.2 and TLSv1.3:

    -L TLSv1.2,TLSv1.3

Add also option -1 to allow also passing other phase1 settings directly (as per https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf)

Example: force PEAP version 0 and use cryptobinding if server supports it

    -1 'peapver=0 crypto_binding=1'